### PR TITLE
chore(renovate): track `_VERSION` variables in Containerfiles

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -1,0 +1,16 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  customManagers: [
+    {
+      description: "Update `_VERSION` variables in Containerfiles",
+      customType: "regex",
+      managerFilePatterns: [
+        "/(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$/",
+        "/(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$/"
+      ],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
+      ],
+    }
+  ]
+}

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -4,6 +4,7 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests",
     "github>JackMyers001/containers//.renovate/autoMerge.json5",
+    "github>JackMyers001/containers//.renovate/customManagers.json5",
     ":disableRateLimiting",
     ":semanticCommits",
     ":timezone(Australia/Perth)",


### PR DESCRIPTION
Adds a custom manager to Renovate to detect and update `ARG` or `ENV` variables suffixed with `_VERSION` inside Containerfiles.

This allows us to track versions for tools installed manually (e.g., via `curl` or binary downloads), rather than just base images.

Based on [this example](https://docs.renovatebot.com/modules/manager/regex/#regular-expression-capture-groups) from the Renovate docs.

## Usage

```dockerfile
# renovate: datasource=github-tags depName=node packageName=nodejs/node versioning=node
ENV NODE_VERSION=20.10.0

# renovate: datasource=github-releases depName=composer packageName=composer/composer
ENV COMPOSER_VERSION=1.9.3

# renovate: datasource=docker packageName=docker versioning=docker
ENV DOCKER_VERSION=19.03.1

# renovate: datasource=npm packageName=yarn
ENV YARN_VERSION=1.19.1
```